### PR TITLE
chore: find least permissions for egress/ingress

### DIFF
--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -10,14 +10,13 @@ spec:
         service: {{ include "wfapi.fullname" . }}
         selector:
           app.kubernetes.io/name: {{ include "wfapi.fullname" . }}
-        host: {{ .Values.wfapi.udsPackage.expose.host}}
+        host: {{ .Values.wfapi.udsPackage.expose.host }}
         gateway: tenant
         port: 80
     allow:
-      - direction: Egress
-        selector: {}
-        remoteGenerated: Anywhere
       - direction: Ingress
-        selector: {}
-        remoteGenerated: Anywhere
+        selector:
+          app.kubernetes.io/name: {{ include "wfapi.fullname" . }}
+        ports:
+          - 8080
 {{- end }}


### PR DESCRIPTION
* KubeAPI access and other ingress / egress stuff is largely handled by the Argo Workflows package
* Limits the WFAPI Package to the WFAPI VirtualService and 8080 (targetPort) ingress

Tables decision to include an AuthService gateway.

Closes #74 
