### PR TITLE
fix: use targetPort instead of allowing ingress on 8080

### DIFF
--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -13,10 +13,5 @@ spec:
         host: {{ .Values.wfapi.udsPackage.expose.host }}
         gateway: tenant
         port: 80
-    allow:
-      - direction: Ingress
-        selector:
-          app.kubernetes.io/name: {{ include "wfapi.fullname" . }}
-        ports:
-          - 8080
+        targetPort: 8080
 {{- end }}


### PR DESCRIPTION
Uses the `targetPort` on the `network.expose` field instead of creating an entire allow ingress field.