### PR TITLE
fix: Add AWSSDK.SecurityToken dependency

### DIFF
--- a/wfapi/wfapi.csproj
+++ b/wfapi/wfapi.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
         <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.301" />
         <PackageReference Include="AWSSDK.S3" Version="3.7.402.7" />
+        <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.400.20" />
         <PackageReference Include="JsonSubTypes" Version="2.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />


### PR DESCRIPTION
Add AWSSDK.SecurityToken dependency in attempt to get IRSA to work. See #90 