### PR TITLE
fix: add time to e2e tests for lower resource requests

### DIFF
--- a/wfapi.E2ETests/V1/Controllers/WorkflowsControllerTests.cs
+++ b/wfapi.E2ETests/V1/Controllers/WorkflowsControllerTests.cs
@@ -288,7 +288,7 @@ public class WorkflowsControllerTests(ITestOutputHelper output)
             // .And()
             // .Header("Connection", "keep-alive")
             .And()
-            .ResponseTime(Is.LessThan(TimeSpan.FromSeconds(24)));
+            .ResponseTime(Is.LessThan(TimeSpan.FromSeconds(30)));
 
         // Do it one more time. This time it should happen extremely quickly since we know the pod is done initializing.
         HttpResponseMessage response = Given()
@@ -306,7 +306,7 @@ public class WorkflowsControllerTests(ITestOutputHelper output)
             // .And()
             // .Header("Connection", "keep-alive")
             .And()
-            .ResponseTime(Is.LessThan(TimeSpan.FromSeconds(2)))
+            .ResponseTime(Is.LessThan(TimeSpan.FromSeconds(5)))
             .And()
             .Extract().Response();
 


### PR DESCRIPTION
Increases the testing time requirements since the resource requests were lowered for the runner.