### PR TITLE
feat: Keycloak ServiceAccounts

### DIFF
--- a/.env
+++ b/.env
@@ -8,4 +8,4 @@ UDS_CLI_VERSION=0.21.0
 # renovate: datasource=github-tags depName=k3d-io/k3d
 K3D_VERSION=5.8.3
 # renovate: datasource=github-tags depName=defenseunicorns-partnerships/argo-wf-zarf
-ARGO_WORKFLOWS_VERSION=0.1.20
+ARGO_WORKFLOWS_VERSION=1.0.0

--- a/docs/diagrams/c4-container.puml
+++ b/docs/diagrams/c4-container.puml
@@ -31,7 +31,7 @@ Rel_R(mission_app, wfapi_authservice, "HTTPS w/ JWT", "Mission App must go throu
 Rel_R(wfapi_authservice, wfapi, "w/ JWT", "Don't redirect to Keycloak if no JWT, just reject")
 Rel_R(wfapi, argo_server, "K8s Access Token", "Primary")
 Rel_D(wfapi, k8s_api1, "K8s Access Token", "Secondary, prefer using Argo Server")
-Rel_D(argo_server, k8s_api2, "K8s Access Token")
+Rel_D(argo_server, k8s_api2, "w/ Argo Server ServiceAccount JWT")
 
 SHOW_FLOATING_LEGEND()
 Lay_D(end_user, LEGEND())

--- a/dotnet/argo-server-client/src/Org.OpenAPITools/Api/ArtifactServiceApi.cs
+++ b/dotnet/argo-server-client/src/Org.OpenAPITools/Api/ArtifactServiceApi.cs
@@ -169,9 +169,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="nodeId"></param>
         /// <param name="artifactName"></param>
         /// <param name="artifactDiscriminator"></param>
+        /// <param name="authHeader"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of FileParameter</returns>
-        System.Threading.Tasks.Task<FileParameter> ArtifactServiceGetArtifactFileAsync(string varNamespace, string idDiscriminator, string id, string nodeId, string artifactName, string artifactDiscriminator, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<FileParameter> ArtifactServiceGetArtifactFileAsync(string varNamespace, string idDiscriminator, string id, string nodeId, string artifactName, string artifactDiscriminator, string authHeader, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get an artifact.
@@ -186,9 +187,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="nodeId"></param>
         /// <param name="artifactName"></param>
         /// <param name="artifactDiscriminator"></param>
+        /// <param name="authHeader"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (FileParameter)</returns>
-        System.Threading.Tasks.Task<ApiResponse<FileParameter>> ArtifactServiceGetArtifactFileWithHttpInfoAsync(string varNamespace, string idDiscriminator, string id, string nodeId, string artifactName, string artifactDiscriminator, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<FileParameter>> ArtifactServiceGetArtifactFileWithHttpInfoAsync(string varNamespace, string idDiscriminator, string id, string nodeId, string artifactName, string artifactDiscriminator, string authHeader, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Get an input artifact.
         /// </summary>
@@ -619,11 +621,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="nodeId"></param>
         /// <param name="artifactName"></param>
         /// <param name="artifactDiscriminator"></param>
+        /// <param name="authHeader"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of FileParameter</returns>
-        public async System.Threading.Tasks.Task<FileParameter> ArtifactServiceGetArtifactFileAsync(string varNamespace, string idDiscriminator, string id, string nodeId, string artifactName, string artifactDiscriminator, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<FileParameter> ArtifactServiceGetArtifactFileAsync(string varNamespace, string idDiscriminator, string id, string nodeId, string artifactName, string artifactDiscriminator, string authHeader, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<FileParameter> localVarResponse = await ArtifactServiceGetArtifactFileWithHttpInfoAsync(varNamespace, idDiscriminator, id, nodeId, artifactName, artifactDiscriminator, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<FileParameter> localVarResponse = await ArtifactServiceGetArtifactFileWithHttpInfoAsync(varNamespace, idDiscriminator, id, nodeId, artifactName, artifactDiscriminator, authHeader, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -637,9 +640,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="nodeId"></param>
         /// <param name="artifactName"></param>
         /// <param name="artifactDiscriminator"></param>
+        /// <param name="authHeader"></param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (FileParameter)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<FileParameter>> ArtifactServiceGetArtifactFileWithHttpInfoAsync(string varNamespace, string idDiscriminator, string id, string nodeId, string artifactName, string artifactDiscriminator, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<FileParameter>> ArtifactServiceGetArtifactFileWithHttpInfoAsync(string varNamespace, string idDiscriminator, string id, string nodeId, string artifactName, string artifactDiscriminator, string authHeader, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'varNamespace' is set
             if (varNamespace == null)
@@ -691,10 +695,7 @@ namespace Org.OpenAPITools.Api
             localVarRequestOptions.PathParameters.Add("artifactDiscriminator", Org.OpenAPITools.Client.ClientUtils.ParameterToString(artifactDiscriminator)); // path parameter
 
             // authentication (BearerToken) required
-            if (!string.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("Authorization")))
-            {
-                localVarRequestOptions.HeaderParameters.Add("Authorization", this.Configuration.GetApiKeyWithPrefix("Authorization"));
-            }
+            localVarRequestOptions.HeaderParameters.Add("Authorization", authHeader);
 
             // make the HTTP request
 

--- a/dotnet/argo-server-client/src/Org.OpenAPITools/Api/WorkflowServiceApi.cs
+++ b/dotnet/argo-server-client/src/Org.OpenAPITools/Api/WorkflowServiceApi.cs
@@ -87,10 +87,11 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="varNamespace"></param>
         /// <param name="name"></param>
+        /// <param name="authHeader"></param>
         /// <param name="getOptionsResourceVersion">resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.  Defaults to unset +optional (optional)</param>
         /// <param name="fields">Fields to be included or excluded in the response. e.g. \&quot;spec,status.phase\&quot;, \&quot;-status.nodes\&quot;. (optional)</param>
         /// <returns>IoArgoprojWorkflowV1alpha1Workflow</returns>
-        IoArgoprojWorkflowV1alpha1Workflow WorkflowServiceGetWorkflow(string varNamespace, string name, string? getOptionsResourceVersion = default(string?), string? fields = default(string?));
+        IoArgoprojWorkflowV1alpha1Workflow WorkflowServiceGetWorkflow(string varNamespace, string name, string authHeader, string? getOptionsResourceVersion = default(string?), string? fields = default(string?));
 
         /// <summary>
         ///
@@ -101,10 +102,11 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="varNamespace"></param>
         /// <param name="name"></param>
+        /// <param name="authHeader"></param>
         /// <param name="getOptionsResourceVersion">resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.  Defaults to unset +optional (optional)</param>
         /// <param name="fields">Fields to be included or excluded in the response. e.g. \&quot;spec,status.phase\&quot;, \&quot;-status.nodes\&quot;. (optional)</param>
         /// <returns>ApiResponse of IoArgoprojWorkflowV1alpha1Workflow</returns>
-        ApiResponse<IoArgoprojWorkflowV1alpha1Workflow> WorkflowServiceGetWorkflowWithHttpInfo(string varNamespace, string name, string? getOptionsResourceVersion = default(string?), string? fields = default(string?));
+        ApiResponse<IoArgoprojWorkflowV1alpha1Workflow> WorkflowServiceGetWorkflowWithHttpInfo(string varNamespace, string name, string authHeader, string? getOptionsResourceVersion = default(string?), string? fields = default(string?));
         /// <summary>
         ///
         /// </summary>
@@ -325,8 +327,9 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="varNamespace"></param>
         /// <param name="body"></param>
+        /// <param name="authHeader"></param>
         /// <returns>IoArgoprojWorkflowV1alpha1Workflow</returns>
-        IoArgoprojWorkflowV1alpha1Workflow WorkflowServiceSubmitWorkflow(string varNamespace, IoArgoprojWorkflowV1alpha1WorkflowSubmitRequest body);
+        IoArgoprojWorkflowV1alpha1Workflow WorkflowServiceSubmitWorkflow(string varNamespace, IoArgoprojWorkflowV1alpha1WorkflowSubmitRequest body, string authHeader);
 
         /// <summary>
         ///
@@ -337,8 +340,9 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="varNamespace"></param>
         /// <param name="body"></param>
+        /// <param name="authHeader"></param>
         /// <returns>ApiResponse of IoArgoprojWorkflowV1alpha1Workflow</returns>
-        ApiResponse<IoArgoprojWorkflowV1alpha1Workflow> WorkflowServiceSubmitWorkflowWithHttpInfo(string varNamespace, IoArgoprojWorkflowV1alpha1WorkflowSubmitRequest body);
+        ApiResponse<IoArgoprojWorkflowV1alpha1Workflow> WorkflowServiceSubmitWorkflowWithHttpInfo(string varNamespace, IoArgoprojWorkflowV1alpha1WorkflowSubmitRequest body, string authHeader);
         /// <summary>
         ///
         /// </summary>
@@ -1656,12 +1660,13 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="varNamespace"></param>
         /// <param name="name"></param>
+        /// <param name="authHeader"></param>
         /// <param name="getOptionsResourceVersion">resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.  Defaults to unset +optional (optional)</param>
         /// <param name="fields">Fields to be included or excluded in the response. e.g. \&quot;spec,status.phase\&quot;, \&quot;-status.nodes\&quot;. (optional)</param>
         /// <returns>IoArgoprojWorkflowV1alpha1Workflow</returns>
-        public IoArgoprojWorkflowV1alpha1Workflow WorkflowServiceGetWorkflow(string varNamespace, string name, string? getOptionsResourceVersion = default(string?), string? fields = default(string?))
+        public IoArgoprojWorkflowV1alpha1Workflow WorkflowServiceGetWorkflow(string varNamespace, string name, string authHeader, string? getOptionsResourceVersion = default(string?), string? fields = default(string?))
         {
-            Org.OpenAPITools.Client.ApiResponse<IoArgoprojWorkflowV1alpha1Workflow> localVarResponse = WorkflowServiceGetWorkflowWithHttpInfo(varNamespace, name, getOptionsResourceVersion, fields);
+            Org.OpenAPITools.Client.ApiResponse<IoArgoprojWorkflowV1alpha1Workflow> localVarResponse = WorkflowServiceGetWorkflowWithHttpInfo(varNamespace, name, authHeader, getOptionsResourceVersion, fields);
             return localVarResponse.Data;
         }
 
@@ -1671,10 +1676,11 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="varNamespace"></param>
         /// <param name="name"></param>
+        /// <param name="authHeader"></param>
         /// <param name="getOptionsResourceVersion">resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.  Defaults to unset +optional (optional)</param>
         /// <param name="fields">Fields to be included or excluded in the response. e.g. \&quot;spec,status.phase\&quot;, \&quot;-status.nodes\&quot;. (optional)</param>
         /// <returns>ApiResponse of IoArgoprojWorkflowV1alpha1Workflow</returns>
-        public Org.OpenAPITools.Client.ApiResponse<IoArgoprojWorkflowV1alpha1Workflow> WorkflowServiceGetWorkflowWithHttpInfo(string varNamespace, string name, string? getOptionsResourceVersion = default(string?), string? fields = default(string?))
+        public Org.OpenAPITools.Client.ApiResponse<IoArgoprojWorkflowV1alpha1Workflow> WorkflowServiceGetWorkflowWithHttpInfo(string varNamespace, string name, string authHeader, string? getOptionsResourceVersion = default(string?), string? fields = default(string?))
         {
             // verify the required parameter 'varNamespace' is set
             if (varNamespace == null)
@@ -1712,10 +1718,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // authentication (BearerToken) required
-            if (!string.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("Authorization")))
-            {
-                localVarRequestOptions.HeaderParameters.Add("Authorization", this.Configuration.GetApiKeyWithPrefix("Authorization"));
-            }
+            localVarRequestOptions.HeaderParameters.Add("Authorization", authHeader);
 
             // make the HTTP request
             var localVarResponse = this.Client.Get<IoArgoprojWorkflowV1alpha1Workflow>("/api/v1/workflows/{namespace}/{name}", localVarRequestOptions, this.Configuration);
@@ -3277,10 +3280,11 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="varNamespace"></param>
         /// <param name="body"></param>
+        /// <param name="authHeader"></param>
         /// <returns>IoArgoprojWorkflowV1alpha1Workflow</returns>
-        public IoArgoprojWorkflowV1alpha1Workflow WorkflowServiceSubmitWorkflow(string varNamespace, IoArgoprojWorkflowV1alpha1WorkflowSubmitRequest body)
+        public IoArgoprojWorkflowV1alpha1Workflow WorkflowServiceSubmitWorkflow(string varNamespace, IoArgoprojWorkflowV1alpha1WorkflowSubmitRequest body, string authHeader)
         {
-            Org.OpenAPITools.Client.ApiResponse<IoArgoprojWorkflowV1alpha1Workflow> localVarResponse = WorkflowServiceSubmitWorkflowWithHttpInfo(varNamespace, body);
+            Org.OpenAPITools.Client.ApiResponse<IoArgoprojWorkflowV1alpha1Workflow> localVarResponse = WorkflowServiceSubmitWorkflowWithHttpInfo(varNamespace, body, authHeader);
             return localVarResponse.Data;
         }
 
@@ -3290,8 +3294,9 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="varNamespace"></param>
         /// <param name="body"></param>
+        /// <param name="authHeader"></param>
         /// <returns>ApiResponse of IoArgoprojWorkflowV1alpha1Workflow</returns>
-        public Org.OpenAPITools.Client.ApiResponse<IoArgoprojWorkflowV1alpha1Workflow> WorkflowServiceSubmitWorkflowWithHttpInfo(string varNamespace, IoArgoprojWorkflowV1alpha1WorkflowSubmitRequest body)
+        public Org.OpenAPITools.Client.ApiResponse<IoArgoprojWorkflowV1alpha1Workflow> WorkflowServiceSubmitWorkflowWithHttpInfo(string varNamespace, IoArgoprojWorkflowV1alpha1WorkflowSubmitRequest body, string authHeader)
         {
             // verify the required parameter 'varNamespace' is set
             if (varNamespace == null)
@@ -3322,10 +3327,8 @@ namespace Org.OpenAPITools.Api
             localVarRequestOptions.Data = body;
 
             // authentication (BearerToken) required
-            if (!string.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("Authorization")))
-            {
-                localVarRequestOptions.HeaderParameters.Add("Authorization", this.Configuration.GetApiKeyWithPrefix("Authorization"));
-            }
+
+            localVarRequestOptions.HeaderParameters.Add("Authorization", authHeader);
 
             // make the HTTP request
             var localVarResponse = this.Client.Post<IoArgoprojWorkflowV1alpha1Workflow>("/api/v1/workflows/{namespace}/submit", localVarRequestOptions, this.Configuration);

--- a/dotnet/argo-server-client/src/Org.OpenAPITools/Api/WorkflowServiceApi.cs
+++ b/dotnet/argo-server-client/src/Org.OpenAPITools/Api/WorkflowServiceApi.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Mime;
+using Duende.IdentityModel.Client;
 using Org.OpenAPITools.Client;
 using Org.OpenAPITools.Model;
 
@@ -589,11 +590,13 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="varNamespace"></param>
         /// <param name="name"></param>
+        /// <param name="authHeader"></param>
         /// <param name="getOptionsResourceVersion">resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.  Defaults to unset +optional (optional)</param>
         /// <param name="fields">Fields to be included or excluded in the response. e.g. \&quot;spec,status.phase\&quot;, \&quot;-status.nodes\&quot;. (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of IoArgoprojWorkflowV1alpha1Workflow</returns>
-        System.Threading.Tasks.Task<IoArgoprojWorkflowV1alpha1Workflow> WorkflowServiceGetWorkflowAsync(string varNamespace, string name, string? getOptionsResourceVersion = default(string?), string? fields = default(string?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<IoArgoprojWorkflowV1alpha1Workflow> WorkflowServiceGetWorkflowAsync(string varNamespace, string name, string authHeader,
+                                                                string? getOptionsResourceVersion = default(string?), string? fields = default(string?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         ///
@@ -604,11 +607,13 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="varNamespace"></param>
         /// <param name="name"></param>
+        /// <param name="authHeader"></param>
         /// <param name="getOptionsResourceVersion">resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.  Defaults to unset +optional (optional)</param>
         /// <param name="fields">Fields to be included or excluded in the response. e.g. \&quot;spec,status.phase\&quot;, \&quot;-status.nodes\&quot;. (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (IoArgoprojWorkflowV1alpha1Workflow)</returns>
-        System.Threading.Tasks.Task<ApiResponse<IoArgoprojWorkflowV1alpha1Workflow>> WorkflowServiceGetWorkflowWithHttpInfoAsync(string varNamespace, string name, string? getOptionsResourceVersion = default(string?), string? fields = default(string?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<IoArgoprojWorkflowV1alpha1Workflow>> WorkflowServiceGetWorkflowWithHttpInfoAsync(string varNamespace, string name, string authHeader,
+                                                                string? getOptionsResourceVersion = default(string?), string? fields = default(string?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         ///
         /// </summary>
@@ -1738,13 +1743,16 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="varNamespace"></param>
         /// <param name="name"></param>
+        /// <param name="authHeader"></param>
         /// <param name="getOptionsResourceVersion">resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.  Defaults to unset +optional (optional)</param>
         /// <param name="fields">Fields to be included or excluded in the response. e.g. \&quot;spec,status.phase\&quot;, \&quot;-status.nodes\&quot;. (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of IoArgoprojWorkflowV1alpha1Workflow</returns>
-        public async System.Threading.Tasks.Task<IoArgoprojWorkflowV1alpha1Workflow> WorkflowServiceGetWorkflowAsync(string varNamespace, string name, string? getOptionsResourceVersion = default(string?), string? fields = default(string?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<IoArgoprojWorkflowV1alpha1Workflow> WorkflowServiceGetWorkflowAsync(string varNamespace, string name, string authHeader,
+                                                string? getOptionsResourceVersion = default(string?), string? fields = default(string?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<IoArgoprojWorkflowV1alpha1Workflow> localVarResponse = await WorkflowServiceGetWorkflowWithHttpInfoAsync(varNamespace, name, getOptionsResourceVersion, fields, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<IoArgoprojWorkflowV1alpha1Workflow> localVarResponse = await WorkflowServiceGetWorkflowWithHttpInfoAsync(varNamespace, name, authHeader,
+                                                getOptionsResourceVersion, fields, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1754,11 +1762,13 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="varNamespace"></param>
         /// <param name="name"></param>
+        /// <param name="authHeader"></param>
         /// <param name="getOptionsResourceVersion">resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.  Defaults to unset +optional (optional)</param>
         /// <param name="fields">Fields to be included or excluded in the response. e.g. \&quot;spec,status.phase\&quot;, \&quot;-status.nodes\&quot;. (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (IoArgoprojWorkflowV1alpha1Workflow)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<IoArgoprojWorkflowV1alpha1Workflow>> WorkflowServiceGetWorkflowWithHttpInfoAsync(string varNamespace, string name, string? getOptionsResourceVersion = default(string?), string? fields = default(string?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<IoArgoprojWorkflowV1alpha1Workflow>> WorkflowServiceGetWorkflowWithHttpInfoAsync(string varNamespace, string name, string authHeader,
+                                                string? getOptionsResourceVersion = default(string?), string? fields = default(string?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'varNamespace' is set
             if (varNamespace == null)
@@ -1798,10 +1808,8 @@ namespace Org.OpenAPITools.Api
             }
 
             // authentication (BearerToken) required
-            if (!string.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("Authorization")))
-            {
-                localVarRequestOptions.HeaderParameters.Add("Authorization", this.Configuration.GetApiKeyWithPrefix("Authorization"));
-            }
+
+            localVarRequestOptions.HeaderParameters.Add("Authorization", authHeader);
 
             // make the HTTP request
 

--- a/dotnet/argo-server-client/src/Org.OpenAPITools/Client/ClientCredentials.cs
+++ b/dotnet/argo-server-client/src/Org.OpenAPITools/Client/ClientCredentials.cs
@@ -34,6 +34,7 @@ public class ClientCredentials{
 /// <exception cref="ApiException"></exception>
    public async Task<string> GetClientCredentialToken()
    {
+
       var client = new HttpClient();
       var tokenResponse = await client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
         {
@@ -48,7 +49,7 @@ public class ClientCredentials{
          throw new ApiException(500, tokenResponse.Error);
       }
 
-      return tokenResponse.AccessToken;
+      return $"Bearer {tokenResponse.AccessToken}";
    }
 
 }

--- a/dotnet/argo-server-client/src/Org.OpenAPITools/Client/ClientCredentials.cs
+++ b/dotnet/argo-server-client/src/Org.OpenAPITools/Client/ClientCredentials.cs
@@ -1,0 +1,38 @@
+using Microsoft.IdentityModel.Client;
+using Newtonsoft.Json.Linq;
+using System.Net.Http.Headers;
+using System.Net.Http;
+
+namespace Org.OpenAPITools.Client;
+
+public class ClientCredentials{
+   /// <summary>
+   /// Handles getting the client credential grant from the OIDC Provider
+   /// </summary>
+   /// <param name="configuration"></param>
+
+   public ClientCrednetials(Configuration configuration)
+   {
+      this.Configuration = configuration;
+   }
+
+   public async string GetClientCredentialToken()
+   {
+      var client = new HttpClient();
+      var tokenResponse = await client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+        {
+            Address = this.Configuration.IdentityPath,
+            ClientId = this.Configuration.ClientId,
+            ClientSecret = this.Configuration.ClientSecret,
+            Scope = "openid"
+        });
+
+      if (tokenResponse.IsError)
+      {
+         throw new ApiException(tokenResponse.StatusCode, tokenResponse.StatusDescription);
+      }
+
+      return tokenResponse.AccessToken;
+   }
+
+}

--- a/dotnet/argo-server-client/src/Org.OpenAPITools/Client/ClientCredentials.cs
+++ b/dotnet/argo-server-client/src/Org.OpenAPITools/Client/ClientCredentials.cs
@@ -1,35 +1,51 @@
-using Microsoft.IdentityModel.Client;
-using Newtonsoft.Json.Linq;
-using System.Net.Http.Headers;
+using Duende.IdentityModel.Client;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Org.OpenAPITools.Client;
 
+/// <summary>
+/// A class to handle ClientCredential grants
+/// </summary>
 public class ClientCredentials{
-   /// <summary>
-   /// Handles getting the client credential grant from the OIDC Provider
-   /// </summary>
-   /// <param name="configuration"></param>
 
-   public ClientCrednetials(Configuration configuration)
+   private string IdentityPath { get; set; }
+   private string ClientId { get; set; }
+   private string ClientSecret{ get; set; }
+
+/// <summary>
+/// Default constructor, needs identity provider url, client id and client secret
+/// </summary>
+/// <param name="IdentityPath"></param>
+/// <param name="clientId"></param>
+/// <param name="clientSecret"></param>
+   public ClientCredentials(string IdentityPath, string clientId, string clientSecret)
    {
-      this.Configuration = configuration;
+
+      this.IdentityPath = IdentityPath;
+      this.ClientId = clientId;
+      this.ClientSecret = clientSecret;
    }
 
-   public async string GetClientCredentialToken()
+/// <summary>
+/// Gets a JWT from the IdP's Client Credentials Grant
+/// </summary>
+/// <returns>raw JWT String</returns>
+/// <exception cref="ApiException"></exception>
+   public async Task<string> GetClientCredentialToken()
    {
       var client = new HttpClient();
       var tokenResponse = await client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
         {
-            Address = this.Configuration.IdentityPath,
-            ClientId = this.Configuration.ClientId,
-            ClientSecret = this.Configuration.ClientSecret,
+            Address = this.IdentityPath,
+            ClientId = this.ClientId,
+            ClientSecret = this.ClientSecret,
             Scope = "openid"
         });
 
       if (tokenResponse.IsError)
       {
-         throw new ApiException(tokenResponse.StatusCode, tokenResponse.StatusDescription);
+         throw new ApiException(500, tokenResponse.Error);
       }
 
       return tokenResponse.AccessToken;

--- a/dotnet/argo-server-client/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/dotnet/argo-server-client/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="8.5.2" />
+    <PackageReference Include="Duende.IdentityModel" version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/chart/docs/values-properties-wfapi-properties-env-properties-auth__jwt__token.md
+++ b/dotnet/chart/docs/values-properties-wfapi-properties-env-properties-auth__jwt__token.md
@@ -1,0 +1,23 @@
+# Auth\_\_Jwt\_\_Token Schema
+
+```txt
+values.yaml#/properties/wfapi/properties/env/properties/Auth__Jwt__Token
+```
+
+Token endpoint to get client credentials
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                           |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [values.schema.json\*](../values.schema.json "open original schema") |
+
+## Auth\_\_Jwt\_\_Token Type
+
+`string` ([Auth\_\_Jwt\_\_Token](values-properties-wfapi-properties-env-properties-auth__jwt__token.md))
+
+## Auth\_\_Jwt\_\_Token Default Value
+
+The default value is:
+
+```json
+"https://sso.uds.dev/realms/uds/protocol/openid-connect/token"
+```

--- a/dotnet/chart/docs/values-properties-wfapi-properties-env.md
+++ b/dotnet/chart/docs/values-properties-wfapi-properties-env.md
@@ -27,6 +27,7 @@ Environment variables to set in the container. Ref: <https://kubernetes.io/docs/
 | [Auth\_\_Jwt\_\_Audience](#auth__jwt__audience)                         | `string` | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-env-properties-auth__jwt__audience.md "values.yaml#/properties/wfapi/properties/env/properties/Auth__Jwt__Audience")                         |
 | [Auth\_\_Jwt\_\_Authority](#auth__jwt__authority)                       | `string` | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-env-properties-auth__jwt__authority.md "values.yaml#/properties/wfapi/properties/env/properties/Auth__Jwt__Authority")                       |
 | [Auth\_\_Jwt\_\_RequireHttpsMetadata](#auth__jwt__requirehttpsmetadata) | `string` | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-env-properties-auth__jwt__requirehttpsmetadata.md "values.yaml#/properties/wfapi/properties/env/properties/Auth__Jwt__RequireHttpsMetadata") |
+| [Auth\_\_Jwt\_\_Token](#auth__jwt__token)                               | `string` | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-env-properties-auth__jwt__token.md "values.yaml#/properties/wfapi/properties/env/properties/Auth__Jwt__Token")                               |
 | [Auth\_\_Jwt\_\_ValidateIssuer](#auth__jwt__validateissuer)             | `string` | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-env-properties-auth__jwt__validateissuer.md "values.yaml#/properties/wfapi/properties/env/properties/Auth__Jwt__ValidateIssuer")             |
 | [Auth\_\_Jwt\_\_WellKnownConfig](#auth__jwt__wellknownconfig)           | `string` | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-env-properties-auth__jwt__wellknownconfig.md "values.yaml#/properties/wfapi/properties/env/properties/Auth__Jwt__WellKnownConfig")           |
 | [Bucket\_\_Name](#bucket__name)                                         | `string` | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-env-properties-bucket__name.md "values.yaml#/properties/wfapi/properties/env/properties/Bucket__Name")                                       |
@@ -253,6 +254,32 @@ The default value is:
 
 ```json
 "true"
+```
+
+## Auth\_\_Jwt\_\_Token
+
+Token endpoint to get client credentials
+
+`Auth__Jwt__Token`
+
+* is required
+
+* Type: `string` ([Auth\_\_Jwt\_\_Token](values-properties-wfapi-properties-env-properties-auth__jwt__token.md))
+
+* cannot be null
+
+* defined in: [values.yaml](values-properties-wfapi-properties-env-properties-auth__jwt__token.md "values.yaml#/properties/wfapi/properties/env/properties/Auth__Jwt__Token")
+
+### Auth\_\_Jwt\_\_Token Type
+
+`string` ([Auth\_\_Jwt\_\_Token](values-properties-wfapi-properties-env-properties-auth__jwt__token.md))
+
+### Auth\_\_Jwt\_\_Token Default Value
+
+The default value is:
+
+```json
+"https://sso.uds.dev/realms/uds/protocol/openid-connect/token"
 ```
 
 ## Auth\_\_Jwt\_\_ValidateIssuer

--- a/dotnet/chart/docs/values-properties-wfapi-properties-envfromsecrets-properties-argoclient.md
+++ b/dotnet/chart/docs/values-properties-wfapi-properties-envfromsecrets-properties-argoclient.md
@@ -1,0 +1,15 @@
+# argoClient Schema
+
+```txt
+values.yaml#/properties/wfapi/properties/envFromSecrets/properties/argoClient
+```
+
+SecretName to mount for client secret, needs clientId and secret fields
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                           |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [values.schema.json\*](../values.schema.json "open original schema") |
+
+## argoClient Type
+
+`string` ([argoClient](values-properties-wfapi-properties-envfromsecrets-properties-argoclient.md))

--- a/dotnet/chart/docs/values-properties-wfapi-properties-envfromsecrets-properties.md
+++ b/dotnet/chart/docs/values-properties-wfapi-properties-envfromsecrets-properties.md
@@ -1,0 +1,15 @@
+# Untitled undefined type in values.yaml Schema
+
+```txt
+values.yaml#/properties/wfapi/properties/envFromSecrets/properties
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                           |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [values.schema.json\*](../values.schema.json "open original schema") |
+
+## properties Type
+
+unknown

--- a/dotnet/chart/docs/values-properties-wfapi-properties-envfromsecrets.md
+++ b/dotnet/chart/docs/values-properties-wfapi-properties-envfromsecrets.md
@@ -1,0 +1,39 @@
+# envFromSecrets Schema
+
+```txt
+values.yaml#/properties/wfapi/properties/envFromSecrets
+```
+
+Environment variabels to mount from secrets form secretName: key. Ref: <https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables>
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                           |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Forbidden             | none                | [values.schema.json\*](../values.schema.json "open original schema") |
+
+## envFromSecrets Type
+
+`object` ([envFromSecrets](values-properties-wfapi-properties-envfromsecrets.md))
+
+# envFromSecrets Properties
+
+| Property                  | Type     | Required | Nullable       | Defined by                                                                                                                                                                |
+| :------------------------ | :------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [argoClient](#argoclient) | `string` | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-envfromsecrets-properties-argoclient.md "values.yaml#/properties/wfapi/properties/envFromSecrets/properties/argoClient") |
+
+## argoClient
+
+SecretName to mount for client secret, needs clientId and secret fields
+
+`argoClient`
+
+* is required
+
+* Type: `string` ([argoClient](values-properties-wfapi-properties-envfromsecrets-properties-argoclient.md))
+
+* cannot be null
+
+* defined in: [values.yaml](values-properties-wfapi-properties-envfromsecrets-properties-argoclient.md "values.yaml#/properties/wfapi/properties/envFromSecrets/properties/argoClient")
+
+### argoClient Type
+
+`string` ([argoClient](values-properties-wfapi-properties-envfromsecrets-properties-argoclient.md))

--- a/dotnet/chart/docs/values-properties-wfapi.md
+++ b/dotnet/chart/docs/values-properties-wfapi.md
@@ -20,6 +20,7 @@ wfapi chart settings
 | :---------------------------------------- | :------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
 | [affinity](#affinity)                     | `object` | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-affinity.md "values.yaml#/properties/wfapi/properties/affinity")                     |
 | [env](#env)                               | `object` | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-env.md "values.yaml#/properties/wfapi/properties/env")                               |
+| [envFromSecrets](#envfromsecrets)         | `object` | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-envfromsecrets.md "values.yaml#/properties/wfapi/properties/envFromSecrets")         |
 | [fullnameOverride](#fullnameoverride)     | `string` | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-fullnameoverride.md "values.yaml#/properties/wfapi/properties/fullnameOverride")     |
 | [image](#image)                           | `object` | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-image.md "values.yaml#/properties/wfapi/properties/image")                           |
 | [imagePullSecrets](#imagepullsecrets)     | `array`  | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-imagepullsecrets.md "values.yaml#/properties/wfapi/properties/imagePullSecrets")     |
@@ -85,6 +86,24 @@ Environment variables to set in the container. Ref: <https://kubernetes.io/docs/
 ### env Type
 
 `object` ([env](values-properties-wfapi-properties-env.md))
+
+## envFromSecrets
+
+Environment variabels to mount from secrets form secretName: key. Ref: <https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables>
+
+`envFromSecrets`
+
+* is required
+
+* Type: `object` ([envFromSecrets](values-properties-wfapi-properties-envfromsecrets.md))
+
+* cannot be null
+
+* defined in: [values.yaml](values-properties-wfapi-properties-envfromsecrets.md "values.yaml#/properties/wfapi/properties/envFromSecrets")
+
+### envFromSecrets Type
+
+`object` ([envFromSecrets](values-properties-wfapi-properties-envfromsecrets.md))
 
 ## fullnameOverride
 

--- a/dotnet/chart/templates/deployment.yaml
+++ b/dotnet/chart/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
               value: {{ $val | quote }}
             {{- end }}
             {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envFromSecrets.argoClient }}
           ports:
             - name: http
               containerPort: {{ .Values.wfapi.service.port }}

--- a/dotnet/chart/templates/deployment.yaml
+++ b/dotnet/chart/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             {{- end }}
           envFrom:
             - secretRef:
-                name: {{ .Values.envFromSecrets.argoClient }}
+                name: {{ .Values.wfapi.envFromSecrets.argoClient }}
           ports:
             - name: http
               containerPort: {{ .Values.wfapi.service.port }}

--- a/dotnet/chart/values.schema.json
+++ b/dotnet/chart/values.schema.json
@@ -98,6 +98,14 @@
                 "string"
               ]
             },
+            "Auth__Jwt__Token": {
+              "default": "https://sso.uds.dev/realms/uds/protocol/openid-connect/token",
+              "description": "Token endpoint to get client credentials",
+              "title": "Auth__Jwt__Token",
+              "type": [
+                "string"
+              ]
+            },
             "Auth__Jwt__ValidateIssuer": {
               "default": "true",
               "description": "Whether to validate the JWT issuer",
@@ -163,6 +171,7 @@
             "Auth__Jwt__Audience",
             "Auth__Jwt__RequireHttpsMetadata",
             "Auth__Jwt__ValidateIssuer",
+            "Auth__Jwt__Token",
             "Argo__ApiUrl",
             "Argo__Token",
             "Argo__Namespace",
@@ -174,6 +183,27 @@
             "Swagger__Enable"
           ],
           "title": "env",
+          "type": [
+            "object"
+          ]
+        },
+        "envFromSecrets": {
+          "additionalProperties": false,
+          "description": "Environment variabels to mount from secrets form secretName: key. Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables",
+          "properties": {
+            "argoClient": {
+              "default": "",
+              "description": "SecretName to mount for client secret, needs clientId and secret fields",
+              "title": "argoClient",
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "required": [
+            "argoClient"
+          ],
+          "title": "envFromSecrets",
           "type": [
             "object"
           ]
@@ -905,6 +935,7 @@
         "nameOverride",
         "fullnameOverride",
         "env",
+        "envFromSecrets",
         "serviceAccount",
         "roleBinding",
         "udsPackage",

--- a/dotnet/chart/values.yaml
+++ b/dotnet/chart/values.yaml
@@ -18,6 +18,7 @@ wfapi: # @schema title: wfapi; type: [object]; description: wfapi chart settings
     Auth__Jwt__Audience: "wfapi" # @schema title: Auth__Jwt__Audience; type: [string]; description: JWT audience. Corresponds to the Keycloak client associated with this app.; required: true; default: "wfapi"
     Auth__Jwt__RequireHttpsMetadata: "true" # @schema title: Auth__Jwt__RequireHttpsMetadata; type: [string]; description: Require HTTPS when interfacing with the IDP; required: true; default: "true"
     Auth__Jwt__ValidateIssuer: "true" # @schema title: Auth__Jwt__ValidateIssuer; type: [string]; description: Whether to validate the JWT issuer; required: true; default: "true"
+    Auth__Jwt__Token: "https://sso.uds.dev/realms/uds/protocol/openid-connect/token" # @schema title: Auth__Jwt__Token; type: [string]; description: Token endpoint to get client credentials; required: true; default: "https://sso.uds.dev/realms/uds/protocol/openid-connect/token"
     Argo__ApiUrl: "http://argo-workflows-server:2746" # @schema title: Argo__ApiUrl; type: [string]; description: Argo API URL; required: true; default: "http://argo-workflows-server:2746"
     Argo__Token: "" # @schema title: Argo__Token; type: [string]; description: Optional Argo API token. Not necessary in most cases as the app will fetch the token that is mounted to the filesystem. Leave as an empty string.; required: true; default: ""
     Argo__Namespace: "argo" # @schema title: Argo__Namespace; type: [string]; description: Namespace where workflows should be created; required: true; default: "argo"
@@ -27,6 +28,9 @@ wfapi: # @schema title: wfapi; type: [object]; description: wfapi chart settings
     AWS_ACCESS_KEY_ID: "" # @schema title: AWS_ACCESS_KEY_ID; type: [string]; description: AWS access key ID. Leave as empty string if using IRSA; required: true; default: ""
     AWS_SECRET_ACCESS_KEY: "" # @schema title: AWS_SECRET_ACCESS_KEY; type: [string]; description: AWS secret access key. Leave as empty string if using IRSA; required: true; default: ""
     Swagger__Enable: "false" # @schema title: Swagger__Enable; type: [string]; description: Whether to enable Swagger. If true, the SwaggerUI can be reached at <url>/swagger; required: true; default: "false"
+
+  envFromSecrets: # @schema title: envFromSecrets; type: [object]; description: Environment variabels to mount from secrets form secretName: key. Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables; required: true; additionalProperties: false
+    argoClient: "argo-workflows-client" # @schema title: argoClient; type: [string]; description: SecretName to mount for client secret, needs clientId and secret fields; required: true; default: ""
 
   serviceAccount: # @schema title: serviceAccount; type: [object]; description: Service account settings; additionalProperties: false; required: true
     create: true # @schema title: create; type: [boolean]; description: Specifies whether a service account should be created; required: true; default: true

--- a/dotnet/wfapi/ArgoClient.cs
+++ b/dotnet/wfapi/ArgoClient.cs
@@ -13,7 +13,8 @@ public class ArgoClient
     /// </summary>
     /// <param name="varNamespace"></param>
     /// <param name="configuration"></param>
-    public ArgoClient(string varNamespace, Configuration configuration)
+    /// <param name="OidcClient"></param>
+    public ArgoClient(string varNamespace, Configuration configuration, ClientCredentials OidcClient)
     {
         this.Namespace = varNamespace;
         this.WorkflowServiceApi = new WorkflowServiceApi(configuration);

--- a/dotnet/wfapi/ArgoClient.cs
+++ b/dotnet/wfapi/ArgoClient.cs
@@ -13,8 +13,7 @@ public class ArgoClient
     /// </summary>
     /// <param name="varNamespace"></param>
     /// <param name="configuration"></param>
-    /// <param name="OidcClient"></param>
-    public ArgoClient(string varNamespace, Configuration configuration, ClientCredentials OidcClient)
+    public ArgoClient(string varNamespace, Configuration configuration)
     {
         this.Namespace = varNamespace;
         this.WorkflowServiceApi = new WorkflowServiceApi(configuration);

--- a/dotnet/wfapi/IWorkflowServiceSseApiAsync.cs
+++ b/dotnet/wfapi/IWorkflowServiceSseApiAsync.cs
@@ -16,6 +16,7 @@ public interface IWorkflowServiceSseApiAsync
     /// <param name="varNamespace"></param>
     /// <param name="name"></param>
     /// <param name="podName"> (optional)</param>
+    /// <param name="authHeader"></param>
     /// <param name="logOptionsContainer">The container for which to stream logs. Defaults to only container if there is one container in the pod. +optional. (optional)</param>
     /// <param name="logOptionsFollow">Follow the log stream of the pod. Defaults to false. +optional. (optional)</param>
     /// <param name="logOptionsPrevious">Return previous terminated container logs. Defaults to false. +optional. (optional)</param>
@@ -34,6 +35,7 @@ public interface IWorkflowServiceSseApiAsync
     IAsyncEnumerable<StreamResultOfIoArgoprojWorkflowV1alpha1LogEntry> WorkflowServiceWorkflowLogsAsync(
         string varNamespace,
         string name,
+        string authHeader,
         string? podName = default(string?),
         string? logOptionsContainer = default(string?),
         bool? logOptionsFollow = default(bool?),
@@ -58,6 +60,7 @@ public interface IWorkflowServiceSseApiAsync
     /// <param name="varNamespace"></param>
     /// <param name="name"></param>
     /// <param name="podName"> (optional)</param>
+    /// <param name="authHeader"></param>
     /// <param name="logOptionsContainer">The container for which to stream logs. Defaults to only container if there is one container in the pod. +optional. (optional)</param>
     /// <param name="logOptionsFollow">Follow the log stream of the pod. Defaults to false. +optional. (optional)</param>
     /// <param name="logOptionsPrevious">Return previous terminated container logs. Defaults to false. +optional. (optional)</param>
@@ -75,6 +78,7 @@ public interface IWorkflowServiceSseApiAsync
     IAsyncEnumerable<ApiResponse<StreamResultOfIoArgoprojWorkflowV1alpha1LogEntry>>
         WorkflowServiceWorkflowLogsWithHttpInfoAsync(string varNamespace,
             string name,
+            string authHeader,
             string? podName = default(string?),
             string? logOptionsContainer = default(string?),
             bool? logOptionsFollow = default(bool?),

--- a/dotnet/wfapi/IWorkflowServiceSseApiAsync.cs
+++ b/dotnet/wfapi/IWorkflowServiceSseApiAsync.cs
@@ -59,8 +59,8 @@ public interface IWorkflowServiceSseApiAsync
     /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
     /// <param name="varNamespace"></param>
     /// <param name="name"></param>
-    /// <param name="podName"> (optional)</param>
     /// <param name="authHeader"></param>
+    /// <param name="podName"> (optional)</param>
     /// <param name="logOptionsContainer">The container for which to stream logs. Defaults to only container if there is one container in the pod. +optional. (optional)</param>
     /// <param name="logOptionsFollow">Follow the log stream of the pod. Defaults to false. +optional. (optional)</param>
     /// <param name="logOptionsPrevious">Return previous terminated container logs. Defaults to false. +optional. (optional)</param>

--- a/dotnet/wfapi/Program.cs
+++ b/dotnet/wfapi/Program.cs
@@ -142,11 +142,7 @@ try
     {
         BasePath = builder.Configuration.GetValue<string>("Argo:ApiUrl") ?? throw new InvalidOperationException()
     };
-    string identityPath = builder.Configuration.GetValue<string>("Auth:Jwt:Token") ?? throw new InvalidOperationException();
-    string ClientId = builder.Configuration.GetValue<string>("clientId") ?? throw new InvalidOperationException();
-    string ClientSecret = builder.Configuration.GetValue<string>("secret") ?? throw new InvalidOperationException();
     var token = builder.Configuration.GetValue<string>("Argo:Token");
-    ClientCredentials OidcClient = new ClientCredentials(identityPath, ClientId, ClientSecret);
     if (String.IsNullOrWhiteSpace(token))
     {
         token = File.ReadAllText("/var/run/secrets/kubernetes.io/serviceaccount/token");
@@ -159,8 +155,7 @@ try
     //argoConfig.AddApiKey("Authorization", token);
     //argoConfig.AddApiKeyPrefix("Authorization", "Bearer");
     var varNamespace = builder.Configuration.GetValue<string>("Argo:Namespace") ?? throw new InvalidOperationException();
-    builder.Services.AddSingleton(new ArgoClient(varNamespace, argoConfig, OidcClient));
-
+    builder.Services.AddSingleton(new ArgoClient(varNamespace, argoConfig));
     // Object Storage setup. Officially supported object storage providers are AWS S3 and MinIO.
     var bucketRegion = builder.Configuration.GetValue<string>("Bucket:Region") ?? throw new InvalidOperationException();
     var bucketServiceUrl = builder.Configuration.GetValue<string>("Bucket:ServiceUrl") ?? throw new InvalidOperationException();
@@ -179,6 +174,11 @@ try
             )
         )
     );
+
+    string identityPath = builder.Configuration.GetValue<string>("Auth:Jwt:Token") ?? throw new InvalidOperationException();
+    string ClientId = builder.Configuration.GetValue<string>("clientId") ?? throw new InvalidOperationException();
+    string ClientSecret = builder.Configuration.GetValue<string>("secret") ?? throw new InvalidOperationException();
+    builder.Services.AddSingleton(new ClientCredentials(identityPath, ClientId, ClientSecret));
 
     var app = builder.Build();
 

--- a/dotnet/wfapi/Program.cs
+++ b/dotnet/wfapi/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Client;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using Org.OpenAPITools.Api;
@@ -141,6 +142,9 @@ try
     var argoConfig = new Configuration
     {
         BasePath = builder.Configuration.GetValue<string>("Argo:ApiUrl") ?? throw new InvalidOperationException()
+        IdentityPath = builder.Configuration.GetValue<string>("Auth:Jwt:Token");
+        ClientId = builder.Configuration.GetValue<string>("clientId");
+        ClientSecret = builder.configuration.GetValue<string>("secret");
     };
     var token = builder.Configuration.GetValue<string>("Argo:Token");
     if (String.IsNullOrWhiteSpace(token))
@@ -152,8 +156,8 @@ try
     {
         Log.Information("Using token from configuration");
     }
-    argoConfig.AddApiKey("Authorization", token);
-    argoConfig.AddApiKeyPrefix("Authorization", "Bearer");
+    //argoConfig.AddApiKey("Authorization", token);
+    //argoConfig.AddApiKeyPrefix("Authorization", "Bearer");
     var varNamespace = builder.Configuration.GetValue<string>("Argo:Namespace") ?? throw new InvalidOperationException();
     builder.Services.AddSingleton(new ArgoClient(varNamespace, argoConfig));
 

--- a/dotnet/wfapi/V1/Controllers/WorkflowsController.cs
+++ b/dotnet/wfapi/V1/Controllers/WorkflowsController.cs
@@ -346,13 +346,13 @@ public class WorkflowsController(ArgoClient argoClient, S3Client s3Client, Clien
         try
         {
             await foreach (var logEntry in argoClient.WorkflowServiceSseApiAsync.WorkflowServiceWorkflowLogsAsync(
-                               varNamespace: argoClient.Namespace,
-                               name: workflowName,
-                               podName: podName,
-                               authHeader: authHeader,
-                               logOptionsContainer: "main",
-                               logOptionsFollow: true,
-                               cancellationToken: cancellationToken
+                            varNamespace: argoClient.Namespace,
+                            name: workflowName,
+                            authHeader: authHeader,
+                            podName: podName,
+                            logOptionsContainer: "main",
+                            logOptionsFollow: true,
+                            cancellationToken: cancellationToken
                            ))
             {
                 // log.LogInformation(JsonConvert.SerializeObject(logEntry));

--- a/dotnet/wfapi/WorkflowServiceSseApiAsync.cs
+++ b/dotnet/wfapi/WorkflowServiceSseApiAsync.cs
@@ -55,7 +55,8 @@ public class WorkflowServiceSseApiAsync : IWorkflowServiceSseApiAsync
     }
 
     /// <inheritdoc />
-    public async IAsyncEnumerable<StreamResultOfIoArgoprojWorkflowV1alpha1LogEntry> WorkflowServiceWorkflowLogsAsync(string varNamespace, string name, string? podName = default(string?),
+    public async IAsyncEnumerable<StreamResultOfIoArgoprojWorkflowV1alpha1LogEntry> WorkflowServiceWorkflowLogsAsync(string varNamespace, string name, string authHeader,
+        string? podName = default(string?),
         string? logOptionsContainer = default(string?), bool? logOptionsFollow = default(bool?),
         bool? logOptionsPrevious = default(bool?), string? logOptionsSinceSeconds = default(string?),
         string? logOptionsSinceTimeSeconds = default(string?), int? logOptionsSinceTimeNanos = default(int?),
@@ -68,6 +69,7 @@ public class WorkflowServiceSseApiAsync : IWorkflowServiceSseApiAsync
         await foreach (var apiResponse in WorkflowServiceWorkflowLogsWithHttpInfoAsync(varNamespace,
                            name,
                            podName,
+                           authHeader,
                            logOptionsContainer,
                            logOptionsFollow,
                            logOptionsPrevious,
@@ -87,7 +89,7 @@ public class WorkflowServiceSseApiAsync : IWorkflowServiceSseApiAsync
     }
 
     /// <inheritdoc />
-    public async IAsyncEnumerable<ApiResponse<StreamResultOfIoArgoprojWorkflowV1alpha1LogEntry>> WorkflowServiceWorkflowLogsWithHttpInfoAsync(string varNamespace, string name,
+    public async IAsyncEnumerable<ApiResponse<StreamResultOfIoArgoprojWorkflowV1alpha1LogEntry>> WorkflowServiceWorkflowLogsWithHttpInfoAsync(string varNamespace, string name, string authHeader,
         string? podName = default(string?), string? logOptionsContainer = default(string?),
         bool? logOptionsFollow = default(bool?), bool? logOptionsPrevious = default(bool?),
         string? logOptionsSinceSeconds = default(string?), string? logOptionsSinceTimeSeconds = default(string?),
@@ -179,10 +181,8 @@ public class WorkflowServiceSseApiAsync : IWorkflowServiceSseApiAsync
         }
 
         // authentication (BearerToken) required
-        if (!string.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("Authorization")))
-        {
-            localVarRequestOptions.HeaderParameters.Add("Authorization", this.Configuration.GetApiKeyWithPrefix("Authorization"));
-        }
+        localVarRequestOptions.HeaderParameters.Add("Authorization", authHeader);
+
 
         // make the HTTP request
 

--- a/dotnet/wfapi/WorkflowServiceSseApiAsync.cs
+++ b/dotnet/wfapi/WorkflowServiceSseApiAsync.cs
@@ -67,22 +67,22 @@ public class WorkflowServiceSseApiAsync : IWorkflowServiceSseApiAsync
         [EnumeratorCancellation] CancellationToken cancellationToken = default(CancellationToken))
     {
         await foreach (var apiResponse in WorkflowServiceWorkflowLogsWithHttpInfoAsync(varNamespace,
-                           name,
-                           podName,
-                           authHeader,
-                           logOptionsContainer,
-                           logOptionsFollow,
-                           logOptionsPrevious,
-                           logOptionsSinceSeconds,
-                           logOptionsSinceTimeSeconds,
-                           logOptionsSinceTimeNanos,
-                           logOptionsTimestamps,
-                           logOptionsTailLines,
-                           logOptionsLimitBytes,
-                           logOptionsInsecureSkipTLSVerifyBackend,
-                           grep,
-                           selector,
-                           cancellationToken).ConfigureAwait(false))
+                        name,
+                        authHeader,
+                        podName,
+                        logOptionsContainer,
+                        logOptionsFollow,
+                        logOptionsPrevious,
+                        logOptionsSinceSeconds,
+                        logOptionsSinceTimeSeconds,
+                        logOptionsSinceTimeNanos,
+                        logOptionsTimestamps,
+                        logOptionsTailLines,
+                        logOptionsLimitBytes,
+                        logOptionsInsecureSkipTLSVerifyBackend,
+                        grep,
+                        selector,
+                        cancellationToken).ConfigureAwait(false))
         {
             yield return apiResponse.Data;
         }

--- a/dotnet/wfapi/appsettings.json
+++ b/dotnet/wfapi/appsettings.json
@@ -32,5 +32,7 @@
     "ApiUrl": "http://localhost:2746",
     "Token": null,
     "Namespace": "argo"
-  }
+  },
+  "clientId": "argo-client",
+  "secret": "secret"
 }


### PR DESCRIPTION
This Branch implements using Keycloak ServiceAccounts for the AuthHeader to the Argo Server.

It only refactors the implemented methods in the underlying OpenAPI methods from Argo Server:
* `WorkflowServiceSubmitWorkflow`
* `WorkflowServiceSubmitWorkflowWithHttpInfo`
* `WorkflowServiceGetWorkflow`
* `WorkflowServiceGetWorkflowWithHttpInfo`
* `WorkflowServiceGetWorkflowAsync`
* `WorkflowServiceGetWorkflowAsyncWithHttpInfo`
* `WorkflowServiceSseApiAsync.WorkflowServiceWorkflowLogsAsync`
* `WorkflowServiceSseApiAsync.WorkflowServiceWorkflowLogsAsyncWithHttpInfo`
* `ArtifactServiceGetArtifactFileAsync`
* `ArtifactServiceGetArtifactFileAsyncWithHttpInfo`