### PR TITLE
fix: azp claim

### DIFF
--- a/.env
+++ b/.env
@@ -8,4 +8,4 @@ UDS_CLI_VERSION=0.21.0
 # renovate: datasource=github-tags depName=k3d-io/k3d
 K3D_VERSION=5.8.3
 # renovate: datasource=github-tags depName=defenseunicorns-partnerships/argo-wf-zarf
-ARGO_WORKFLOWS_VERSION=1.0.0
+ARGO_WORKFLOWS_VERSION=1.1.0

--- a/dotnet/chart/docs/values-properties-wfapi-properties-udspackage-properties-s3port.md
+++ b/dotnet/chart/docs/values-properties-wfapi-properties-udspackage-properties-s3port.md
@@ -1,0 +1,23 @@
+# s3Port Schema
+
+```txt
+values.yaml#/properties/wfapi/properties/udsPackage/properties/s3Port
+```
+
+Egress allowed on the port to connect to S3
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                           |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [values.schema.json\*](../values.schema.json "open original schema") |
+
+## s3Port Type
+
+`number` ([s3Port](values-properties-wfapi-properties-udspackage-properties-s3port.md))
+
+## s3Port Default Value
+
+The default value is:
+
+```json
+9000
+```

--- a/dotnet/chart/docs/values-properties-wfapi-properties-udspackage.md
+++ b/dotnet/chart/docs/values-properties-wfapi-properties-udspackage.md
@@ -21,6 +21,7 @@ UDS package settings
 | [enabled](#enabled)         | `boolean` | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-udspackage-properties-enabled.md "values.yaml#/properties/wfapi/properties/udsPackage/properties/enabled")         |
 | [expose](#expose)           | `object`  | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-udspackage-properties-expose.md "values.yaml#/properties/wfapi/properties/udsPackage/properties/expose")           |
 | [redirectURI](#redirecturi) | `string`  | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-udspackage-properties-redirecturi.md "values.yaml#/properties/wfapi/properties/udsPackage/properties/redirectURI") |
+| [s3Port](#s3port)           | `number`  | Required | cannot be null | [values.yaml](values-properties-wfapi-properties-udspackage-properties-s3port.md "values.yaml#/properties/wfapi/properties/udsPackage/properties/s3Port")           |
 
 ## enabled
 
@@ -90,4 +91,30 @@ The default value is:
 
 ```json
 "https://wfapi.uds.dev/auth"
+```
+
+## s3Port
+
+Egress allowed on the port to connect to S3
+
+`s3Port`
+
+* is required
+
+* Type: `number` ([s3Port](values-properties-wfapi-properties-udspackage-properties-s3port.md))
+
+* cannot be null
+
+* defined in: [values.yaml](values-properties-wfapi-properties-udspackage-properties-s3port.md "values.yaml#/properties/wfapi/properties/udsPackage/properties/s3Port")
+
+### s3Port Type
+
+`number` ([s3Port](values-properties-wfapi-properties-udspackage-properties-s3port.md))
+
+### s3Port Default Value
+
+The default value is:
+
+```json
+9000
 ```

--- a/dotnet/chart/templates/uds-package.yaml
+++ b/dotnet/chart/templates/uds-package.yaml
@@ -57,4 +57,11 @@ spec:
         remoteNamespace: keycloak
         ports:
           - 8080
+      #S3
+      - direction: Egress
+        description: Egress to S3 for WFAPI
+        selector:
+          app.kubernetes.io/name: {{ include "wfapi.fullname" . }}
+        ports:
+          - {{ .Values.wfapi.udsPackage.s3Port }}
 {{- end }}

--- a/dotnet/chart/values.schema.json
+++ b/dotnet/chart/values.schema.json
@@ -897,12 +897,21 @@
               "description": "Redirect URI for Keycloak client",
               "title": "redirectURI",
               "type": "string"
+            },
+            "s3Port": {
+              "default": 9000,
+              "description": "Egress allowed on the port to connect to S3",
+              "title": "s3Port",
+              "type": [
+                "number"
+              ]
             }
           },
           "required": [
             "enabled",
             "expose",
-            "redirectURI"
+            "redirectURI",
+            "s3Port"
           ],
           "title": "udsPackage",
           "type": [

--- a/dotnet/chart/values.yaml
+++ b/dotnet/chart/values.yaml
@@ -47,6 +47,7 @@ wfapi: # @schema title: wfapi; type: [object]; description: wfapi chart settings
     expose: # @schema title: expose; type: [object]; description: Expose settings; additionalProperties: false; required: true
       host: wfapi # @schema title: host; type: [string]; description: Hostname to expose the app on; required: true; default: "wfapi"
     redirectURI: https://wfapi.uds.dev/auth # @schema title: redirectURI; type[string]; description: Redirect URI for Keycloak client; required: true; default: "https://wfapi.uds.dev/auth"
+    s3Port: 9000 # @schema title: s3Port; type: number; description: Egress allowed on the port to connect to S3; required: true; default: 9000
 
   podAnnotations: {} # @schema title: podAnnotations; type: [object]; description: Annotations to add to the pod. Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/; required: true; default: {}
   podLabels: {} # @schema title: podLabels; description: Labels to add to the pod. Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/; type: [object]; required: true; default: {}

--- a/dotnet/tasks/ci.yaml
+++ b/dotnet/tasks/ci.yaml
@@ -32,7 +32,7 @@ tasks:
           linux: bash
         cmd: |
             set -a; source ../../../.env; set +a
-            ./uds zarf package deploy -l debug oci://ghcr.io/defenseunicorns-partnerships/argo-wf-zarf/argo-workflows:${ARGO_WORKFLOWS_VERSION}-vanilla --components=dev-setup --confirm
+            ./uds zarf package deploy -l debug oci://ghcr.io/defenseunicorns-partnerships/argo-wf-zarf/argo-workflows:${ARGO_WORKFLOWS_VERSION}-vanilla --confirm
   - name: argo-down
     description: Bring down the test instance of Argo Workflows
     actions:

--- a/dotnet/tasks/tests.yaml
+++ b/dotnet/tasks/tests.yaml
@@ -138,8 +138,8 @@ tasks:
             -H 'Content-Type: application/json' \
             -H "Authorization: Bearer ${JWT}" \
             -d '{
-            "templateName": "hello-world-template",
-            "generateName": "hello-world-",
+            "templateName": "wfapi-api-hello-world-template",
+            "generateName": "wfapi-api-hello-world-",
             "parameters": []
             }'
   - name: submit-dev-workflow

--- a/dotnet/tasks/tests.yaml
+++ b/dotnet/tasks/tests.yaml
@@ -151,7 +151,7 @@ tasks:
             -H 'accept: application/json' \
             -H 'Content-Type: application/json' \
             -d '{
-            "templateName": "hello-world-template",
-            "generateName": "hello-world-",
+            "templateName": "wfapi-api-hello-world-template",
+            "generateName": "wfapi-api-hello-world-",
             "parameters": [{"name": "waitSeconds", "value": "30"}]
             }'

--- a/dotnet/test/argo-workflows/zarf-config.yaml
+++ b/dotnet/test/argo-workflows/zarf-config.yaml
@@ -2,6 +2,8 @@ package:
   deploy:
     set:
       DEPLOY_POSTGRESQL: true
+      DEV_DEPLOYMENT: true
+      POSTGRES_EGRESS: false
       PG_USER: argo
       PG_USER_PASSWORD: argo
       PG_DB: argo_workflows

--- a/dotnet/test/argo-workflows/zarf-config.yaml
+++ b/dotnet/test/argo-workflows/zarf-config.yaml
@@ -2,7 +2,6 @@ package:
   deploy:
     set:
       DEPLOY_POSTGRESQL: true
-      DEV_DEPLOYMENT: true
       POSTGRES_EGRESS: false
       PG_USER: argo
       PG_USER_PASSWORD: argo

--- a/dotnet/test/hello-world-template.yaml
+++ b/dotnet/test/hello-world-template.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: hello-world-template
+  name: wfapi-api-hello-world-template
   namespace: argo
   annotations:
     workflows.argoproj.io/description: |

--- a/dotnet/test/wfapi/zarf-config.yaml
+++ b/dotnet/test/wfapi/zarf-config.yaml
@@ -9,3 +9,4 @@ package:
       CPU_LIMIT: 200m
       MEMORY_LIMIT: 2Gi
       MEMORY_REQUEST: 128Mi
+      S3_PORT: 9000

--- a/dotnet/wfapi.E2ETests/V1/Controllers/WorkflowsControllerTests.cs
+++ b/dotnet/wfapi.E2ETests/V1/Controllers/WorkflowsControllerTests.cs
@@ -21,8 +21,8 @@ namespace wfapi.E2ETests.V1.Controllers;
 public class WorkflowsControllerTests(ITestOutputHelper output)
 {
     private const string RootUrl = "https://wfapi.uds.dev";
-    private const string TemplateName = "hello-world-template";
-    private const string GenerateName = "hello-world-";
+    private const string TemplateName = "wfapi-api-hello-world-template";
+    private const string GenerateName = "wfapi-api-hello-world-";
 
     [Fact]
     public void FileManagementEndpoints_WhenCalled_BehavesAsExpected()
@@ -397,6 +397,6 @@ public class WorkflowsControllerTests(ITestOutputHelper output)
             // .And()
             // .Header("Connection", "keep-alive")
             .And()
-            .ResponseTime(Is.LessThan(TimeSpan.FromMilliseconds(1000)));
+            .ResponseTime(Is.LessThan(TimeSpan.FromMilliseconds(3000)));
     }
 }

--- a/dotnet/wfapi/Program.cs
+++ b/dotnet/wfapi/Program.cs
@@ -76,7 +76,7 @@ try
     });
 
     // SSO
-    string jwt_auds = builder.Configuration.GetValue<string>("Auth:Jwt:Audience");
+    string jwt_auds = builder.Configuration.GetValue<string>("Auth:Jwt:Audience") ?? throw new InvalidOperationException();;
     Log.Information($"Audiences: {jwt_auds}");
     builder.Services.AddAuthentication(options =>
         {
@@ -117,13 +117,13 @@ try
                     // THIS IS THE PART TO CHANGE
                     // We've seen Keycloak put roles in the `resource_access` claim. It scopes them to the ClientID.
                     // We've also seen JWTs without roles, but with a `groups` block. We can use that instead, we'll just need to update this code block.
-                    var client_id = claimsIdentity.FindFirst("client_id")?.Value ?? null;
+                    var presenter = claimsIdentity.FindFirst("azp")?.Value ?? null;
                     // ^^^^^^^^^ CHANGE THIS STUFF ^^^^^^^^^
 
-                    if (client_id == null) return Task.CompletedTask;
+                    if (presenter == null) return Task.CompletedTask;
                     else
                     {
-                        claimsIdentity.AddClaim(new Claim(claimsIdentity.RoleClaimType, client_id));
+                        claimsIdentity.AddClaim(new Claim(claimsIdentity.RoleClaimType, presenter));
                     }
                     return Task.CompletedTask;
                 }

--- a/dotnet/zarf/values.yaml
+++ b/dotnet/zarf/values.yaml
@@ -44,6 +44,7 @@ wfapi:
     expose:
       host: "###ZARF_VAR_UDS_PACKAGE_EXPOSE_HOST###"
     redirectURI: "###ZARF_VAR_UDS_PACKAGE_REDIRECT_URI###"
+    s3Port: !!int "###ZARF_VAR_S3_PORT###"
 
   podAnnotations: {}
   podLabels: {}

--- a/dotnet/zarf/zarf.yaml
+++ b/dotnet/zarf/zarf.yaml
@@ -92,6 +92,10 @@ variables:
     default: "true"
     sensitive: false
     pattern: "^(true|false)$"
+  - name: S3_PORT
+    description: Port to expose for S3 comms
+    default: "9000"
+    sensitive: false
   - name: UDS_PACKAGE_EXPOSE_HOST
     description: The hostname to use when creating the VirtualService
     default: "wfapi"


### PR DESCRIPTION
The new keycloak oidc service account does  not include the `client_id` field in the JWT by default.  Thus, the auth claim is now based on the `azp` field (authorized presenter) which has the same value as the client_id.